### PR TITLE
Remove allowBackup and support for RtL

### DIFF
--- a/permissive/src/main/AndroidManifest.xml
+++ b/permissive/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
 <manifest package="com.cdrussell.permissive"
           xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-                 android:supportsRtl="true"
-    >
-
-    </application>
+    <application android:label="@string/app_name" />
 
 </manifest>


### PR DESCRIPTION
It's down to the app implementing the library to decide whether to support these attributes and if set in library project it causes manifest merge issues.
